### PR TITLE
Fix undefined log variable

### DIFF
--- a/src/cosmos_guardrail/cosmos_guardrail.py
+++ b/src/cosmos_guardrail/cosmos_guardrail.py
@@ -245,7 +245,7 @@ class LlamaGuard3(torch.nn.Module, ContentSafetyGuardrail):
         try:
             return self.filter_llamaGuard3_output(prompt)
         except Exception as e:
-            log.error(f"Unexpected error occurred when running Llama Guard 3 guardrail: {e}")
+            logger.error(f"Unexpected error occurred when running Llama Guard 3 guardrail: {e}")
             return True, "Unexpected error occurred when running Llama Guard 3 guardrail."
 
 


### PR DESCRIPTION
This PR fixes the NameError described in [issue #5](https://github.com/yiyixuxu/cosmos-guardrail/issues/5).

I've corrected the undefined `log` variable to the declared `logger` within the `is_safe` function's exception block.

**Test Code**
```python
from cosmos_guardrail import CosmosSafetyChecker 
# Example text prompt to check
prompt_input = "naked women"

# Initialize the safety checker
safety_checker = CosmosSafetyChecker()

# Mock function to bypass llamaGuard3 model running error
safety_checker.text_guardrail.safety_models[1].filter_llamaGuard3_output = None

# Check text safety
is_text_safe = safety_checker.check_text_safety(prompt_input)

```

**Before fix:** 
```
log.error(f"Unexpected error occurred when running Llama Guard 3 guardrail: {e}")
NameError: name 'log' is not defined
```

**After fix:** 
```
2025-09-18 13:33:23,438 - cosmos_guardrail.cosmos_guardrail - ERROR - Unexpected error occurred when running Llama Guard 3 guardrail: 'NoneType' object is not callable
```